### PR TITLE
Add deployables list functionality

### DIFF
--- a/src/GitTreeVersion.Tests/DeployableScenarios.cs
+++ b/src/GitTreeVersion.Tests/DeployableScenarios.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GitTreeVersion.Paths;
+using NUnit.Framework;
+
+namespace GitTreeVersion.Tests;
+
+internal class DeployableScenarios : GitTestBase
+{
+    private const string Deployable1Path = "Deployable1";
+    private const string Deployable1FileName = $"{Deployable1Path}\\Deployable1.csproj";
+    private const string Deployable2FileName = "Deployable2\\Deployable2.csproj";
+    private const string ReferencedDeployablePath = "GitTreeVersion";
+    private const string ReferencedDeployableFileName = $"{ReferencedDeployablePath}\\GitTreeVersion.csproj";
+
+    [Test]
+    public async Task ListDeployables_OutputAllDeployablesInRepository()
+    {
+        var repositoryPath = CreateGitRepositoryWithDeployables();
+
+        var deployables = await ExecuteCommand("deployable", "ls", repositoryPath.ToString());
+
+        deployables.Should().HaveCount(3);
+        deployables.Should().ContainSingle(x => x.EndsWith(Deployable1FileName));
+        deployables.Should().ContainSingle(x => x.EndsWith(Deployable2FileName));
+        deployables.Should().ContainSingle(x => x.EndsWith(ReferencedDeployableFileName));
+    }
+
+    [Test]
+    public async Task ListImpactedDeployables_WithoutImpactingChanges_DoesNotOutput()
+    {
+        var repositoryPath = CreateGitRepositoryWithDeployables();
+
+        var branch = CreateBranch(repositoryPath);
+        CommitNewFile(repositoryPath);
+
+        MergeBranchToMaster(repositoryPath, branch);
+
+        var deployables = await ExecuteCommand("deployable", "ls", "--only-impacted", repositoryPath.ToString());
+
+        deployables.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ListImpactedDeployables_WithImpactedOnOneDeployable_OutputsImpactedDeployable()
+    {
+        var repositoryPath = CreateGitRepositoryWithDeployables();
+
+        var branch = CreateBranch(repositoryPath);
+        var deployable1File = repositoryPath.CombineToFile(Deployable1Path, "file.cs");
+        await File.WriteAllTextAsync(deployable1File.FullName, Guid.NewGuid().ToString());
+        CommitFile(repositoryPath, deployable1File);
+
+        MergeBranchToMaster(repositoryPath, branch);
+
+        var deployables = await ExecuteCommand("deployable", "ls", "--only-impacted", repositoryPath.ToString());
+
+        deployables.Should().HaveCount(1);
+        deployables.Should().ContainSingle(x => x.EndsWith(Deployable1FileName));
+    }
+
+    [Test]
+    public async Task ListImpactedDeployables_WithImpactedOnReferencedDeployable_OutputsAllImpactedDeployables()
+    {
+        var repositoryPath = CreateGitRepositoryWithDeployables();
+
+        var branch = CreateBranch(repositoryPath);
+        var referencedDeployableFile = repositoryPath.CombineToFile(ReferencedDeployablePath, "file.cs");
+        await File.WriteAllTextAsync(referencedDeployableFile.FullName, Guid.NewGuid().ToString());
+        CommitFile(repositoryPath, referencedDeployableFile);
+
+        MergeBranchToMaster(repositoryPath, branch);
+
+        var deployables = await ExecuteCommand("deployable", "ls", "--only-impacted", repositoryPath.ToString());
+
+        deployables.Should().HaveCount(2);
+        deployables.Should().ContainSingle(x => x.EndsWith(Deployable2FileName));
+        deployables.Should().ContainSingle(x => x.EndsWith(ReferencedDeployableFileName));
+    }
+
+    private AbsoluteDirectoryPath CreateGitRepositoryWithDeployables()
+    {
+        var repositoryPath = CreateGitRepository();
+        var deployablePath1 = new AbsoluteFilePath(
+            Path.Combine(repositoryPath.ToString(), Deployable1FileName));
+        Directory.CreateDirectory(Path.GetDirectoryName(deployablePath1.FullName)!);
+
+        File.WriteAllText(deployablePath1.FullName, ResourceReader.MinimalCsproj);
+        CommitFile(repositoryPath, deployablePath1);
+
+        var deployablePath2 = new AbsoluteFilePath(
+            Path.Combine(repositoryPath.ToString(), Deployable2FileName));
+        Directory.CreateDirectory(Path.GetDirectoryName(deployablePath2.FullName)!);
+
+        File.WriteAllText(deployablePath2.FullName, ResourceReader.GitTreeVersionTestsCsproj);
+        CommitFile(repositoryPath, deployablePath2);
+
+        var referencedDeployable = new AbsoluteFilePath(
+            Path.Combine(repositoryPath.ToString(), ReferencedDeployableFileName));
+        Directory.CreateDirectory(Path.GetDirectoryName(referencedDeployable.FullName)!);
+
+        File.WriteAllText(referencedDeployable.FullName, ResourceReader.MinimalCsproj);
+        CommitFile(repositoryPath, referencedDeployable);
+
+        return repositoryPath;
+    }
+
+    private static async Task<string[]> ExecuteCommand(params string[] args)
+    {
+        var originalIsDebug = Log.IsDebug;
+        var originalOutWriter = Console.Out;
+        var originalErrorWriter = Console.Error;
+
+        try
+        {
+            Log.IsDebug = false;
+            await using var outWriter = new StringWriter();
+            await using var errorWriter = new StringWriter();
+
+            Console.SetOut(outWriter);
+            Console.SetError(errorWriter);
+
+            await Program.Main(args);
+
+            errorWriter.ToString().Should().BeNullOrEmpty();
+            return outWriter.ToString().SplitOutput();
+        }
+        finally
+        {
+            Log.IsDebug = originalIsDebug;
+            Console.SetOut(originalOutWriter);
+            Console.SetError(originalErrorWriter);
+        }
+    }
+}

--- a/src/GitTreeVersion.Tests/GitTestBase.cs
+++ b/src/GitTreeVersion.Tests/GitTestBase.cs
@@ -78,7 +78,7 @@ namespace GitTreeVersion.Tests
             return branchName;
         }
 
-        public void CommitNewFile(AbsoluteDirectoryPath repositoryPath, DateTimeOffset? commitTime = null, string? commitMessage = null)
+        public AbsoluteFilePath CommitNewFile(AbsoluteDirectoryPath repositoryPath, DateTimeOffset? commitTime = null, string? commitMessage = null)
         {
             var fileName = Path.Combine(repositoryPath.ToString(), $"file-{Guid.NewGuid()}");
             File.WriteAllText(fileName, Guid.NewGuid().ToString());
@@ -91,6 +91,8 @@ namespace GitTreeVersion.Tests
 
             var signature = new Signature(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), commitTime.GetValueOrDefault(DateTimeOffset.UtcNow));
             repository.Commit(commitMessage ?? $"add new file {relativeFilePath}", signature, signature);
+
+            return new AbsoluteFilePath(fileName);
         }
 
         public void CommitFile(AbsoluteDirectoryPath repositoryPath, AbsoluteFilePath filePath, DateTimeOffset? commitTime = null, string? commitMessage = null)

--- a/src/GitTreeVersion.Tests/Scenarios.cs
+++ b/src/GitTreeVersion.Tests/Scenarios.cs
@@ -98,6 +98,48 @@ namespace GitTreeVersion.Tests
         }
 
         [Test]
+        public void GetMergeParentCommitHashes()
+        {
+            var repositoryPath = CreateGitRepository();
+
+            CommitNewFile(repositoryPath);
+
+            var branchName = CreateBranch(repositoryPath);
+
+            CommitNewFile(repositoryPath);
+
+            MergeBranchToMaster(repositoryPath, branchName);
+
+            var gitDirectory = new GitDirectory(repositoryPath);
+
+            var (parent1, parent2) = gitDirectory.GetMergeParentCommitHashes();
+
+            parent1.Should().NotBeNullOrWhiteSpace();
+            parent2.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Test]
+        public void GitDiffFileNames()
+        {
+            var repositoryPath = CreateGitRepository();
+
+            CommitNewFile(repositoryPath);
+
+            var branchName = CreateBranch(repositoryPath);
+
+            var newFilePath = CommitNewFile(repositoryPath);
+
+            MergeBranchToMaster(repositoryPath, branchName);
+
+            var gitDirectory = new GitDirectory(repositoryPath);
+
+            var (parent1, parent2) = gitDirectory.GetMergeParentCommitHashes();
+            var gitDiffFileNames = gitDirectory.GitDiffFileNames(parent1, parent2, null);
+
+            gitDiffFileNames.Should().ContainSingle(x => newFilePath.FileName.EndsWith(x));
+        }
+
+        [Test]
         public void NonDefaultBranch()
         {
             var repositoryPath = CreateGitRepository();

--- a/src/GitTreeVersion/Commands/CheckChangedCommand.cs
+++ b/src/GitTreeVersion/Commands/CheckChangedCommand.cs
@@ -28,17 +28,7 @@ namespace GitTreeVersion.Commands
             path ??= Environment.CurrentDirectory;
 
             var gitDirectory = new GitDirectory(new AbsoluteDirectoryPath(path));
-            var output = gitDirectory.RunGit("rev-list", "--parents", "--max-count=1", "HEAD").Trim();
-
-            var commitShas = output.Split(" ");
-
-            if (commitShas.Length != 3)
-            {
-                throw new InvalidOperationException("Last commit is not a merge commit.");
-            }
-
-            var parent1 = commitShas[1];
-            var parent2 = commitShas[2];
+            var(parent1, parent2) = gitDirectory.GetMergeParentCommitHashes();
 
             Console.WriteLine($"Found merge commit with parents {parent1} and {parent2}.");
 
@@ -46,7 +36,12 @@ namespace GitTreeVersion.Commands
             Console.WriteLine("Relevant changed files:");
             Console.WriteLine();
 
-            Console.WriteLine(gitDirectory.RunGit("diff", "--name-only", parent1, parent2).Trim());
+            var fileNames = gitDirectory.GitDiffFileNames(parent1, parent2, null);
+
+            foreach (var fileName in fileNames)
+            {
+                Console.WriteLine(fileName);
+            }
         }
     }
 }

--- a/src/GitTreeVersion/Commands/Deployable/DeployablesCommand.cs
+++ b/src/GitTreeVersion/Commands/Deployable/DeployablesCommand.cs
@@ -1,0 +1,11 @@
+using System.CommandLine;
+
+namespace GitTreeVersion.Commands.Deployable;
+
+public class DeployableCommand : Command
+{
+    public DeployableCommand() : base("deployable", "Manage deployables")
+    {
+        AddCommand(new ListDeployablesCommand());
+    }
+}

--- a/src/GitTreeVersion/Commands/Deployable/ListDeployablesCommand.cs
+++ b/src/GitTreeVersion/Commands/Deployable/ListDeployablesCommand.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Linq;
+using GitTreeVersion.Context;
+using GitTreeVersion.Deployables;
+using GitTreeVersion.Git;
+using GitTreeVersion.Paths;
+
+namespace GitTreeVersion.Commands.Deployable;
+
+internal class ListDeployablesCommand : Command
+{
+    public ListDeployablesCommand() : base("ls", "List deployables")
+    {
+        Handler = CommandHandler.Create<bool, string?>(Execute);
+
+        AddOption(new Option<bool>("--only-changed", "Only list deployables that were impacted"));
+        AddArgument(new Argument<string?>("path", () => "."));
+    }
+
+    private void Execute(bool onlyChanged, string? path)
+    {
+        if (path is not null)
+        {
+            path = Path.GetFullPath(path);
+        }
+
+        path ??= Environment.CurrentDirectory;
+
+        var versionGraph = ContextResolver.GetVersionGraph(new AbsoluteDirectoryPath(path));
+        var deployables = versionGraph.Deployables.Values.AsEnumerable();
+
+        if (onlyChanged)
+        {
+            deployables = FilterChangedDeployables(deployables, versionGraph, path);
+        }
+
+        foreach (var deployable in deployables)
+        {
+            Console.WriteLine(deployable.FilePath.FullName);
+        }
+    }
+
+    private static IEnumerable<IDeployable> FilterChangedDeployables(IEnumerable<IDeployable> deployables, VersionGraph versionGraph, string path)
+    {
+        var gitDirectory = new GitDirectory(new AbsoluteDirectoryPath(path));
+        var(parent1, parent2) = gitDirectory.GetMergeParentCommitHashes();
+        var changedFiles = gitDirectory.GitDiffFileNames(parent1, parent2, null)
+            .Select(Path.GetFullPath)
+            .Select(f => new AbsoluteFilePath(f))
+            .ToArray();
+
+        foreach (var deployable in deployables)
+        {
+            var relatedPaths = GetRelatedPaths(deployable, versionGraph);
+
+            var isImpacted = changedFiles.Any(changedFile => relatedPaths.Any(changedFile.IsInSubPathOf));
+
+            if (!isImpacted)
+            {
+                continue;
+            }
+
+            yield return deployable;
+        }
+    }
+
+    private static IEnumerable<AbsoluteDirectoryPath> GetRelatedPaths(IDeployable deployable, VersionGraph versionGraph)
+    {
+        var deployableQueue = new Queue<IDeployable>(new[] { deployable });
+        var relatedDeployables = new HashSet<AbsoluteFilePath>();
+
+        while (deployableQueue.TryDequeue(out var currentDeployable))
+        {
+            if (!relatedDeployables.Add(currentDeployable.FilePath))
+            {
+                continue;
+            }
+
+            var deployables = deployable.ReferencedDeployablePaths
+                .Except(relatedDeployables)
+                .Select(fp => versionGraph.Deployables[fp]);
+
+            foreach (var relatedDeployable in deployables)
+            {
+                deployableQueue.Enqueue(relatedDeployable);
+            }
+        }
+
+        return relatedDeployables.Select(rd => rd.Parent);
+    }
+}

--- a/src/GitTreeVersion/Commands/Deployable/ListDeployablesCommand.cs
+++ b/src/GitTreeVersion/Commands/Deployable/ListDeployablesCommand.cs
@@ -17,11 +17,11 @@ internal class ListDeployablesCommand : Command
     {
         Handler = CommandHandler.Create<bool, string?>(Execute);
 
-        AddOption(new Option<bool>("--only-changed", "Only list deployables that were impacted"));
+        AddOption(new Option<bool>("--only-impacted", "Only list deployables that were impacted"));
         AddArgument(new Argument<string?>("path", () => "."));
     }
 
-    private void Execute(bool onlyChanged, string? path)
+    private void Execute(bool onlyImpacted, string? path)
     {
         if (path is not null)
         {
@@ -33,9 +33,9 @@ internal class ListDeployablesCommand : Command
         var versionGraph = ContextResolver.GetVersionGraph(new AbsoluteDirectoryPath(path));
         var deployables = versionGraph.Deployables.Values.AsEnumerable();
 
-        if (onlyChanged)
+        if (onlyImpacted)
         {
-            deployables = FilterChangedDeployables(deployables, versionGraph, path);
+            deployables = FilterImpactedDeployables(deployables, versionGraph, path);
         }
 
         foreach (var deployable in deployables)
@@ -44,7 +44,7 @@ internal class ListDeployablesCommand : Command
         }
     }
 
-    private static IEnumerable<IDeployable> FilterChangedDeployables(IEnumerable<IDeployable> deployables, VersionGraph versionGraph, string path)
+    private static IEnumerable<IDeployable> FilterImpactedDeployables(IEnumerable<IDeployable> deployables, VersionGraph versionGraph, string path)
     {
         var gitDirectory = new GitDirectory(new AbsoluteDirectoryPath(path));
         var(parent1, parent2) = gitDirectory.GetMergeParentCommitHashes();

--- a/src/GitTreeVersion/Commands/Deployable/ListDeployablesCommand.cs
+++ b/src/GitTreeVersion/Commands/Deployable/ListDeployablesCommand.cs
@@ -11,7 +11,7 @@ using GitTreeVersion.Paths;
 
 namespace GitTreeVersion.Commands.Deployable;
 
-internal class ListDeployablesCommand : Command
+public class ListDeployablesCommand : Command
 {
     public ListDeployablesCommand() : base("ls", "List deployables")
     {
@@ -49,7 +49,7 @@ internal class ListDeployablesCommand : Command
         var gitDirectory = new GitDirectory(new AbsoluteDirectoryPath(path));
         var(parent1, parent2) = gitDirectory.GetMergeParentCommitHashes();
         var changedFiles = gitDirectory.GitDiffFileNames(parent1, parent2, null)
-            .Select(Path.GetFullPath)
+            .Select(f => Path.Combine(path, f))
             .Select(f => new AbsoluteFilePath(f))
             .ToArray();
 

--- a/src/GitTreeVersion/Git/GitDirectory.cs
+++ b/src/GitTreeVersion/Git/GitDirectory.cs
@@ -222,13 +222,40 @@ namespace GitTreeVersion.Git
             return output.SplitOutput();
         }
 
+        public MergeParentCommitHashes GetMergeParentCommitHashes()
+        {
+            var output = RunGit("rev-list", "--parents", "--max-count=1", "HEAD").Trim();
+
+            var commitShas = output.Split(" ");
+
+            if (commitShas.Length != 3)
+            {
+                throw new InvalidOperationException("Last commit is not a merge commit.");
+            }
+
+            var parent1 = commitShas[1];
+            var parent2 = commitShas[2];
+
+            return new MergeParentCommitHashes(parent1, parent2);
+        }
+
         public string[] GitDiffFileNames(string? range, string? pathSpec)
+        {
+            return GitDiffFileNames(range, null, pathSpec);
+        }
+
+        public string[] GitDiffFileNames(string? rangeStart, string? rangeEnd, string? pathSpec)
         {
             var arguments = new List<string>();
             arguments.Add("diff");
             arguments.Add("--name-only");
 
-            arguments.Add(range ?? "HEAD");
+            arguments.Add(rangeStart ?? "HEAD");
+
+            if (!string.IsNullOrWhiteSpace(rangeEnd))
+            {
+                arguments.Add(rangeEnd);
+            }
 
             if (!string.IsNullOrWhiteSpace(pathSpec))
             {
@@ -335,3 +362,5 @@ namespace GitTreeVersion.Git
         }
     }
 }
+
+public record MergeParentCommitHashes(string Parent1, string Parent2);

--- a/src/GitTreeVersion/Program.cs
+++ b/src/GitTreeVersion/Program.cs
@@ -6,6 +6,7 @@ using System.CommandLine.Parsing;
 using System.Reflection;
 using System.Threading.Tasks;
 using GitTreeVersion.Commands;
+using GitTreeVersion.Commands.Deployable;
 using Spectre.Console;
 
 namespace GitTreeVersion
@@ -23,6 +24,7 @@ namespace GitTreeVersion
             rootCommand.AddCommand(new AnalyzeCommand());
             rootCommand.AddCommand(new TreeCommand());
             rootCommand.AddCommand(new BumpCommand());
+            rootCommand.AddCommand(new DeployableCommand());
 
             var commandLineBuilder = new CommandLineBuilder(rootCommand)
                 .UseVersionOption()


### PR DESCRIPTION
Add functionality to list all deployables in a repository.

usage example:
```
gtv deployable ls
/home/git/my-project/Project1/Project1.csproj
/home/git/my-project/Project2/Project2.csproj
/home/git/my-project/Project3/Project3.csproj
```

usage example with `only-impacted` flag:
> Assume that a file was changed in Project2 which Project3 depends on. Because Project2 is impacted also Project3 is impacted and is therefore listed.
```
gtv deployable ls --only-impacted
/home/git/my-project/Project2/Project2.csproj
/home/git/my-project/Project3/Project3.csproj
```