### PR TITLE
Add --output-versions and formatting to deployable ls command

### DIFF
--- a/src/GitTreeVersion/Formatting/GridResult.cs
+++ b/src/GitTreeVersion/Formatting/GridResult.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace GitTreeVersion.Formatting;
+
+internal abstract class GridResult
+{
+    protected abstract IEnumerable<string> GetColumnNames();
+
+    protected abstract IEnumerable<IEnumerable<object>> GetRows();
+
+    public string RenderAs(OutputFormat format)
+    {
+        return format switch
+        {
+            OutputFormat.Json => RenderAsJson(),
+            OutputFormat.Text => RenderAsText(),
+            _ => throw new NotImplementedException()
+        };
+    }
+
+    private string RenderAsJson()
+    {
+        IEnumerable<JsonObject> ConvertRowsToJsonObjects()
+        {
+            var columnNames = GetColumnNames().ToArray();
+
+            foreach (var row in GetRows())
+            {
+                var columns = row.ToArray();
+                if (columnNames.Length != columns.Length)
+                {
+                    throw new InvalidOperationException("Column count mismatch");
+                }
+
+                var jsonProperties = columnNames.Zip(columns)
+                    .ToDictionary(x => x.First, x => JsonValue.Create(x.Second.ToString()) as JsonNode);
+
+                yield return new JsonObject(jsonProperties);
+            }
+        }
+
+        var jsonObjects = ConvertRowsToJsonObjects().ToArray<JsonNode?>();
+        var result = new JsonArray(jsonObjects);
+
+        return result.ToJsonString(new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+    }
+
+    private string RenderAsText()
+    {
+        IEnumerable<string> JoinColumns()
+        {
+            var columnNames = GetColumnNames().ToArray();
+
+            foreach (var row in GetRows())
+            {
+                var columns = row.ToArray();
+                if (columnNames.Length != columns.Length)
+                {
+                    throw new InvalidOperationException("Column count mismatch");
+                }
+
+                yield return string.Join(';', columns);
+            }
+        }
+
+        return string.Join(Environment.NewLine, JoinColumns());
+    }
+}
+

--- a/src/GitTreeVersion/Formatting/OutputFormat.cs
+++ b/src/GitTreeVersion/Formatting/OutputFormat.cs
@@ -1,0 +1,7 @@
+namespace GitTreeVersion.Formatting;
+
+internal enum OutputFormat
+{
+    Json,
+    Text
+}


### PR DESCRIPTION
Add option to `deployable ls` to include version info.

Usage examples:
```
gtv deployable ls --output-versions
/home/git/my-project/Project1/Project1.csproj;1.1.0
/home/git/my-project/Project2/Project2.csproj;2.0.0
/home/git/my-project/Project3/Project3.csproj;1.1.1
```

Additionally an option has been added to select output format. The default output format is `text`, but you can also specify `json` now.

Usage examples:
```
gtv deployable ls --output-versions --format json
[
  {
    "deployableFilePath": "/home/git/my-project/Project1/Project1.csproj",
    "version": "1.1.0"
  },
  {
    "deployableFilePath": "/home/git/my-project/Project2/Project2.csproj",
    "version": "2.0.0"
  },
  {
    "deployableFilePath": "/home/git/my-project/Project3/Project3.csproj",
    "version": "1.1.1"
  }
]
```